### PR TITLE
Some fixes and add references to the image in the 'notes' field of the Zenodo record

### DIFF
--- a/donodo/__init__.py
+++ b/donodo/__init__.py
@@ -40,12 +40,19 @@ def push(image, token, auto_publish=False, force_upload=False):
         return 0
     return 2
 
-def pull(doi):
+
+def doi_record(doi : str) -> ZenodoImageRecord:
+    zs = ZenodoAnonymousSession()
+    zr = ZenodoImageRecord(zs, doi)
+    return zr
+
+
+def pull(doi : str, zr : ZenodoImageRecord = None):
     """
     Retrieve a Docker image from a zenodo DOI
     """
-    zs = ZenodoAnonymousSession()
-    zr = ZenodoImageRecord(zs, doi)
+    if zr is None:
+        zr = doi_record(doi)
     with zr.open() as fp:
         return docker_load(fp)
 

--- a/donodo/templates.py
+++ b/donodo/templates.py
@@ -20,6 +20,7 @@ deposition_templates = {
     "version": "{image.tag}",
     "publication_date": "{image.labels.get('org.label-schema.build-date', image.inspect['Created'])[:10]}",
     "keywords": ["docker image"],
+    "notes": "{{ \"docker-id\" : \"{image.inspect['Id']}\", \"docker-image-name\" : \"{image.name}:{image.tag}\" }}",
     "description": """<p>This record contains an exportation of the Docker image
     <strong>{image.name}:{image.tag}</strong>.</p>
     <p>The image can be imported using the command <code>docker load</code> with

--- a/donodo/zenodo.py
+++ b/donodo/zenodo.py
@@ -199,6 +199,7 @@ class ZenodoImageRecord(ZenodoRecord):
         url = self.image_file["links"]["self"]
         logger.info(f"Downloading {url}")
         fp = urlopen(url)
-        if self.image_file["type"] == "gz":
-            fp = gzip.GzipFile(fileobj=fp)
+        if (("type" in self.image_file and self.image_file["type"] == "gz") or
+                self.image_file["key"].endswith(".gz")):
+                fp = gzip.GzipFile(fileobj=fp)
         return fp

--- a/donodo/zenodo.py
+++ b/donodo/zenodo.py
@@ -176,6 +176,7 @@ class ZenodoRecord(object):
             assert len(matches) == 1
             self.record = matches[0]
         self.doi = self.record["doi"]
+        self.notes = self.record["metadata"].get("notes", None)
 
 
 class ZenodoImageRecord(ZenodoRecord):

--- a/donodo/zenodo.py
+++ b/donodo/zenodo.py
@@ -34,7 +34,7 @@ class ZenodoSession(object):
             url = self.base_url + url
         logger.debug((url, kwargs))
         ret = getattr(self.session, method)(url, **kwargs)
-        if ret.status_code != 204:
+        if ret.status_code != requests.codes.no_content:
             ret = ret.json()
         if isinstance(ret, dict) and ret.get("status",0) >= 400:
             logger.critical(ret)


### PR DESCRIPTION
1. The type of the image file is checked wrt to the entry 'type' in the record associated to the DOI. 
It would seems that this key does not always exist. I added a test on the file name of the image.

2. In order to ease the retrieval of the docker image name and its identifier in Docker (i.e, its shasum), I added
these informations in the 'notes' entry of the metadata field of the record.
